### PR TITLE
Propagate new command line flag states between instances

### DIFF
--- a/PowerEditor/src/Parameters.h
+++ b/PowerEditor/src/Parameters.h
@@ -269,12 +269,15 @@ struct Session
 struct CmdLineParams
 {
 	bool _isNoPlugin = false;
-	bool _isReadOnly = false;
-	bool _isNoSession = false;
-	bool _isNoTab = false;
-	bool _isPreLaunch = false;
-	bool _showLoadingTime = false;
-	bool _alwaysOnTop = false;
+        bool _isReadOnly = false;
+        bool _isFullReadOnly = false;
+        bool _isFullReadOnlySavingForbidden = false;
+        bool _isNoSession = false;
+        bool _isNoTab = false;
+        bool _isPreLaunch = false;
+        bool _showLoadingTime = false;
+        bool _showHelp = false;
+        bool _alwaysOnTop = false;
 	intptr_t _line2go   = -1;
 	intptr_t _column2go = -1;
 	intptr_t _pos2go = -1;
@@ -283,10 +286,10 @@ struct CmdLineParams
 	bool _isPointXValid = false;
 	bool _isPointYValid = false;
 
-	bool _isSessionFile = false;
-	bool _isRecursive = false;
-	bool _openFoldersAsWorkspace = false;
-	bool _monitorFiles = false;
+        bool _isSessionFile = false;
+        bool _isRecursive = false;
+        bool _openFoldersAsWorkspace = false;
+        bool _monitorFiles = false;
 
 	LangType _langType = L_EXTERNAL;
 	std::wstring _localizationPath;
@@ -313,12 +316,15 @@ struct CmdLineParams
 // A POD (Plain Old Data) class to send CmdLineParams through WM_COPYDATA and to Notepad_plus::loadCommandlineParams
 struct CmdLineParamsDTO
 {
-	bool _isReadOnly = false;
-	bool _isNoSession = false;
-	bool _isSessionFile = false;
-	bool _isRecursive = false;
-	bool _openFoldersAsWorkspace = false;
-	bool _monitorFiles = false;
+        bool _isReadOnly = false;
+        bool _isFullReadOnly = false;
+        bool _isFullReadOnlySavingForbidden = false;
+        bool _isNoSession = false;
+        bool _isSessionFile = false;
+        bool _isRecursive = false;
+        bool _openFoldersAsWorkspace = false;
+        bool _monitorFiles = false;
+        bool _showHelp = false;
 
 	intptr_t _line2go = 0;
 	intptr_t _column2go = 0;
@@ -331,12 +337,15 @@ struct CmdLineParamsDTO
 	static CmdLineParamsDTO FromCmdLineParams(const CmdLineParams& params)
 	{
 		CmdLineParamsDTO dto;
-		dto._isReadOnly = params._isReadOnly;
-		dto._isNoSession = params._isNoSession;
-		dto._isSessionFile = params._isSessionFile;
-		dto._isRecursive = params._isRecursive;
-		dto._openFoldersAsWorkspace = params._openFoldersAsWorkspace;
-		dto._monitorFiles = params._monitorFiles;
+                dto._isReadOnly = params._isReadOnly;
+                dto._isFullReadOnly = params._isFullReadOnly;
+                dto._isFullReadOnlySavingForbidden = params._isFullReadOnlySavingForbidden;
+                dto._isNoSession = params._isNoSession;
+                dto._isSessionFile = params._isSessionFile;
+                dto._isRecursive = params._isRecursive;
+                dto._openFoldersAsWorkspace = params._openFoldersAsWorkspace;
+                dto._monitorFiles = params._monitorFiles;
+                dto._showHelp = params._showHelp;
 
 		dto._line2go = params._line2go;
 		dto._column2go = params._column2go;

--- a/PowerEditor/src/winmain.cpp
+++ b/PowerEditor/src/winmain.cpp
@@ -317,6 +317,8 @@ int getGhostTypingSpeedFromParam(ParamVector & params)
 const wchar_t FLAG_MULTI_INSTANCE[] = L"-multiInst";
 const wchar_t FLAG_NO_PLUGIN[] = L"-noPlugin";
 const wchar_t FLAG_READONLY[] = L"-ro";
+const wchar_t FLAG_FULLREADONLY[] = L"-fullReadOnly";
+const wchar_t FLAG_FULLREADONLY_SAVING_FORBIDDEN[] = L"-fullReadOnlySavingForbidden";
 const wchar_t FLAG_NOSESSION[] = L"-nosession";
 const wchar_t FLAG_NOTABBAR[] = L"-notabbar";
 const wchar_t FLAG_SYSTRAY[] = L"-systemtray";
@@ -598,15 +600,18 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE /*hPrevInstance
 	CmdLineParams cmdLineParams;
 	cmdLineParams._isNoTab = isInList(FLAG_NOTABBAR, params);
 	cmdLineParams._isNoPlugin = isInList(FLAG_NO_PLUGIN, params);
-	cmdLineParams._isReadOnly = isInList(FLAG_READONLY, params);
-	cmdLineParams._isNoSession = isInList(FLAG_NOSESSION, params);
-	cmdLineParams._isPreLaunch = isInList(FLAG_SYSTRAY, params);
-	cmdLineParams._alwaysOnTop = isInList(FLAG_ALWAYS_ON_TOP, params);
-	cmdLineParams._showLoadingTime = isInList(FLAG_LOADINGTIME, params);
-	cmdLineParams._isSessionFile = isInList(FLAG_OPENSESSIONFILE, params);
-	cmdLineParams._isRecursive = isInList(FLAG_RECURSIVE, params);
-	cmdLineParams._openFoldersAsWorkspace = isInList(FLAG_OPEN_FOLDERS_AS_WORKSPACE, params);
-	cmdLineParams._monitorFiles = isInList(FLAG_MONITOR_FILES, params);
+        cmdLineParams._isReadOnly = isInList(FLAG_READONLY, params);
+        cmdLineParams._isFullReadOnly = isInList(FLAG_FULLREADONLY, params);
+        cmdLineParams._isFullReadOnlySavingForbidden = isInList(FLAG_FULLREADONLY_SAVING_FORBIDDEN, params);
+        cmdLineParams._isNoSession = isInList(FLAG_NOSESSION, params);
+        cmdLineParams._isPreLaunch = isInList(FLAG_SYSTRAY, params);
+        cmdLineParams._alwaysOnTop = isInList(FLAG_ALWAYS_ON_TOP, params);
+        cmdLineParams._showLoadingTime = isInList(FLAG_LOADINGTIME, params);
+        cmdLineParams._isSessionFile = isInList(FLAG_OPENSESSIONFILE, params);
+        cmdLineParams._isRecursive = isInList(FLAG_RECURSIVE, params);
+        cmdLineParams._openFoldersAsWorkspace = isInList(FLAG_OPEN_FOLDERS_AS_WORKSPACE, params);
+        cmdLineParams._monitorFiles = isInList(FLAG_MONITOR_FILES, params);
+        cmdLineParams._showHelp = showHelp;
 
 	cmdLineParams._langType = getLangTypeFromParam(params);
 	cmdLineParams._localizationPath = getLocalizationPathFromParam(params);


### PR DESCRIPTION
## Summary
- extend the command line parameter structures to track the new full read-only and help flags
- ensure the WM_COPYDATA payload copies these flags so a secondary launch preserves them
- parse the new command line switches into the stored parameters for forwarding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8e9557a148332a9e8ba5ec118fc9b